### PR TITLE
Properly extend Error

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,2 +1,7 @@
 /* tslint:disable:max-classes-per-file */
-export class ArgumentError extends Error {}
+export class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}


### PR DESCRIPTION
This changes the error name from `Error` to the name of the custom error