### PR TITLE
Catch errors thrown when creating response models

### DIFF
--- a/src/webServiceClient.ts
+++ b/src/webServiceClient.ts
@@ -91,8 +91,16 @@ export default class WebServiceClient {
               this.handleError(data as ResponseError, response, url)
             );
           }
-
-          return resolve(new modelClass(data));
+          try {
+            return resolve(new modelClass(data));
+          } catch (e) {
+            const responseData = data as ResponseError;
+            responseData.code = 'INVALID_RESPONSE_BODY'
+            responseData.error = `Received incomplete response body, could not create ${path} model.`;
+            return reject(
+              this.handleError(responseData, response, url)
+            );
+          }
         });
       });
 
@@ -128,7 +136,7 @@ export default class WebServiceClient {
     }
 
     if (
-      response.statusCode &&
+      response.statusCode != 200 &&
       (response.statusCode < 400 || response.statusCode >= 600)
     ) {
       return {


### PR DESCRIPTION
Sometimes, the json returned by the api is missing the `ip_address.country` field (maybe some others too), which causes an error when trying to build an Insights response model https://github.com/maxmind/minfraud-api-node/blob/d2267dea729b33fb9bf32dc2a3ee3445f3256615/src/response/models/insights.ts#L48

The error happens in an asynchronous context, so the wrapping promise doesn't get rejected and the error bubbles up uncaught.