### PR TITLE
Catch errors thrown when creating response models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.2.1 (2019-10-23)
+-----------------
+
+* Catch errors thrown when creating response models
+
 1.2.0 (2019-09-24)
 -----------------
 

--- a/fixtures/insights.json
+++ b/fixtures/insights.json
@@ -198,6 +198,181 @@
           "input_pointer": "/shipping/city"
         }
       ]
+    },
+    "incomplete": {
+      "id": "5bc5d6c2-b2c8-40af-87f4-6d61af86b6ae",
+      "risk_score": 0.01,
+      "funds_remaining": 25.0,
+      "queries_remaining": 1666,
+
+      "ip_address": {
+        "risk": 0.01,
+        "city": {
+          "confidence": 25,
+          "geoname_id": 54321,
+          "names": {
+            "de": "Los Angeles",
+            "en": "Los Angeles",
+            "es": "Los Ángeles",
+            "fr": "Los Angeles",
+            "ja": "ロサンゼルス市",
+            "pt-BR": "Los Angeles",
+            "ru": "Лос-Анджелес",
+            "zh-CN": "洛杉矶"
+          }
+        },
+        "continent": {
+          "code": "NA",
+          "geoname_id": 123456,
+          "names": {
+            "de": "Nordamerika",
+            "en": "North America",
+            "es": "América del Norte",
+            "fr": "Amérique du Nord",
+            "ja": "北アメリカ",
+            "pt-BR": "América do Norte",
+            "ru": "Северная Америка",
+            "zh-CN": "北美洲"
+          }
+        },
+        "location": {
+          "accuracy_radius": 20,
+          "average_income": 50321,
+          "latitude": 37.6293,
+          "local_time": "2015-04-26T01:37:17-08:00",
+          "longitude": -122.1163,
+          "metro_code": 807,
+          "population_density": 7122,
+          "time_zone": "America/Los_Angeles"
+        },
+        "postal": {
+          "code": "90001",
+          "confidence": 10
+        },
+        "registered_country": {
+          "geoname_id": 6252001,
+          "is_in_european_union": true,
+          "iso_code": "US",
+          "names": {
+            "de": "USA",
+            "en": "United States",
+            "es": "Estados Unidos",
+            "fr": "États-Unis",
+            "ja": "アメリカ合衆国",
+            "pt-BR": "Estados Unidos",
+            "ru": "США",
+            "zh-CN": "美国"
+          }
+        },
+        "represented_country": {
+          "geoname_id": 6252001,
+          "is_in_european_union": true,
+          "iso_code": "US",
+          "names": {
+            "de": "USA",
+            "en": "United States",
+            "es": "Estados Unidos",
+            "fr": "États-Unis",
+            "ja": "アメリカ合衆国",
+            "pt-BR": "Estados Unidos",
+            "ru": "США",
+            "zh-CN": "美国"
+          },
+          "type": "military"
+        },
+        "subdivisions": [
+          {
+            "confidence": 50,
+            "geoname_id": 5332921,
+            "iso_code": "CA",
+            "names": {
+              "de": "Kalifornien",
+              "en": "California",
+              "es": "California",
+              "fr": "Californie",
+              "ja": "カリフォルニア",
+              "ru": "Калифорния",
+              "zh-CN": "加州"
+            }
+          }
+        ],
+        "traits": {
+          "autonomous_system_number": 1239,
+          "autonomous_system_organization": "Linkem IR WiMax Network",
+          "domain": "example.com",
+          "ip_address": "1.2.3.4",
+          "is_anonymous": true,
+          "is_anonymous_proxy": true,
+          "is_anonymous_vpn": true,
+          "is_hosting_provider": true,
+          "is_legitimate_proxy": false,
+          "is_public_proxy": true,
+          "is_satellite_provider": true,
+          "is_tor_exit_node": true,
+          "isp": "Linkem spa",
+          "organization": "Linkem IR WiMax Network",
+          "user_type": "traveler"
+        }
+      },
+
+      "credit_card": {
+        "issuer": {
+          "name": "Bank of America",
+          "matches_provided_name": true,
+          "phone_number": "800-732-9194",
+          "matches_provided_phone_number": true
+        },
+        "brand": "Visa",
+        "country": "US",
+        "is_issued_in_billing_address_country": true,
+        "is_prepaid": true,
+        "is_virtual": true,
+        "type": "credit"
+      },
+
+      "device": {
+        "confidence": 99,
+        "id": "7835b099-d385-4e5b-969e-7df26181d73b",
+        "last_seen": "2016-06-08T14:16:38Z",
+        "local_time": "2018-01-02T10:40:11-08:00"
+      },
+
+      "email": {
+        "first_seen": "2016-02-03",
+        "is_free": false,
+        "is_high_risk": true
+      },
+
+      "shipping_address": {
+        "is_high_risk": true,
+        "is_postal_in_city": true,
+        "latitude": 37.632,
+        "longitude": -122.313,
+        "distance_to_ip_location": 15,
+        "distance_to_billing_address": 22,
+        "is_in_ip_country": true
+      },
+
+      "billing_address": {
+        "is_postal_in_city": true,
+        "latitude": 37.545,
+        "longitude": -122.421,
+        "distance_to_ip_location": 100,
+        "is_in_ip_country": true
+      },
+
+      "disposition": {
+        "action": "accept",
+        "reason": "default"
+      },
+
+      "warnings": [
+        {
+          "code": "INPUT_INVALID",
+          "warning": "Encountered value at /shipping/city that does not meet the required constraints",
+          "input_pointer": "/shipping/city"
+        }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxmind/minfraud-api-node",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Node.js API for MaxMind minFraud Score, Insights, and Factors web services",
   "main": "dist/src/index.js",
   "homepage": "https://github.com/maxmind/minfraud-api-node",

--- a/src/webServiceClient.spec.ts
+++ b/src/webServiceClient.spec.ts
@@ -182,6 +182,22 @@ describe('WebServiceClient', () => {
       });
     });
 
+    it('handles errors with incomplete payload', () => {
+      expect.assertions(1);
+
+      nockInstance
+        .post(fullPath('insights'), insights.request.basic)
+        .basicAuth(auth)
+        .reply(200, insights.response.incomplete);
+
+      return expect(client.insights(transaction)).rejects.toEqual({
+        code: 'INVALID_RESPONSE_BODY',
+        error:
+          "Received incomplete response body, could not create insights model. (Cannot read property 'is_high_risk' of undefined)",
+        url: baseUrl + fullPath('insights'),
+      });
+    });
+
     it('handles general http.request errors', () => {
       const error = {
         code: 'FOO_ERR',

--- a/src/webServiceClient.ts
+++ b/src/webServiceClient.ts
@@ -94,9 +94,10 @@ export default class WebServiceClient {
           try {
             return resolve(new modelClass(data));
           } catch (error) {
-            const responseData = data as ResponseError;
-            responseData.code = 'INVALID_RESPONSE_BODY';
-            responseData.error = `Received incomplete response body, could not create ${path} model. (${error.message})`;
+            const responseData: ResponseError = {
+              code: 'INVALID_RESPONSE_BODY',
+              error: `Received incomplete response body, could not create ${path} model. (${error.message})`,
+            };
             return reject(this.handleError(responseData, response, url));
           }
         });

--- a/src/webServiceClient.ts
+++ b/src/webServiceClient.ts
@@ -95,11 +95,9 @@ export default class WebServiceClient {
             return resolve(new modelClass(data));
           } catch (error) {
             const responseData = data as ResponseError;
-            responseData.code = 'INVALID_RESPONSE_BODY'
+            responseData.code = 'INVALID_RESPONSE_BODY';
             responseData.error = `Received incomplete response body, could not create ${path} model. (${error.message})`;
-            return reject(
-              this.handleError(responseData, response, url)
-            );
+            return reject(this.handleError(responseData, response, url));
           }
         });
       });
@@ -136,7 +134,8 @@ export default class WebServiceClient {
     }
 
     if (
-      response.statusCode != 200 &&
+      response.statusCode &&
+      response.statusCode !== 200 &&
       (response.statusCode < 400 || response.statusCode >= 600)
     ) {
       return {

--- a/src/webServiceClient.ts
+++ b/src/webServiceClient.ts
@@ -91,8 +91,16 @@ export default class WebServiceClient {
               this.handleError(data as ResponseError, response, url)
             );
           }
-
-          return resolve(new modelClass(data));
+          try {
+            return resolve(new modelClass(data));
+          } catch (error) {
+            const responseData = data as ResponseError;
+            responseData.code = 'INVALID_RESPONSE_BODY'
+            responseData.error = `Received incomplete response body, could not create ${path} model. (${error.message})`;
+            return reject(
+              this.handleError(responseData, response, url)
+            );
+          }
         });
       });
 
@@ -128,7 +136,7 @@ export default class WebServiceClient {
     }
 
     if (
-      response.statusCode &&
+      response.statusCode != 200 &&
       (response.statusCode < 400 || response.statusCode >= 600)
     ) {
       return {


### PR DESCRIPTION
Sometimes, the json returned by the api is missing the `ip_address.country` field (maybe some others too), which causes an error when trying to build an Insights response model https://github.com/maxmind/minfraud-api-node/blob/d2267dea729b33fb9bf32dc2a3ee3445f3256615/src/response/models/insights.ts#L48

The error happens in an asynchronous context, so the wrapping promise doesn't get rejected and the error bubbles up uncaught.