### PR TITLE
Handle empty ip_address country and location responses

### DIFF
--- a/src/response/models/insights.spec.ts
+++ b/src/response/models/insights.spec.ts
@@ -1,0 +1,25 @@
+import cloneDeep = require('lodash.clonedeep');
+import * as insights from '../../../fixtures/insights.json';
+import Insights from './insights';
+
+describe('Insights()', () => {
+  it('handles empty country responses', () => {
+    let input = cloneDeep(insights) as any;
+    input = input.response.full;
+    delete input.ip_address.country;
+
+    const model = new Insights(input);
+
+    expect(model.ipAddress.country.isHighRisk).toBeUndefined();
+  });
+
+  it('handles empty location responses', () => {
+    let input = cloneDeep(insights) as any;
+    input = input.response.full;
+    delete input.ip_address.location;
+
+    const model = new Insights(input);
+
+    expect(model.ipAddress.location.localTime).toBeUndefined();
+  });
+});

--- a/src/response/models/insights.ts
+++ b/src/response/models/insights.ts
@@ -45,8 +45,15 @@ export default class Insights extends Score {
     response: webRecords.InsightsResponse
   ): records.IpAddress {
     const insights = new GeoInsights(response.ip_address) as records.IpAddress;
-    insights.country.isHighRisk = response.ip_address.country.is_high_risk;
-    insights.location.localTime = response.ip_address.location.local_time;
+
+    insights.country.isHighRisk = response.ip_address.country
+      ? response.ip_address.country.is_high_risk
+      : undefined;
+
+    insights.location.localTime = response.ip_address.location
+      ? response.ip_address.location.local_time
+      : undefined;
+
     insights.risk = response.ip_address.risk;
 
     delete insights.maxmind;

--- a/src/response/records.ts
+++ b/src/response/records.ts
@@ -16,11 +16,11 @@ export interface GeoIPCountry extends CountryRecord {
    * @category Deprecated
    * @deprecated
    */
-  isHighRisk: boolean;
+  isHighRisk?: boolean;
 }
 
 export interface GeoIPLocation extends LocationRecord {
-  localTime: string;
+  localTime?: string;
 }
 
 export interface IpAddress extends Insights {

--- a/src/response/web-records.ts
+++ b/src/response/web-records.ts
@@ -14,8 +14,8 @@ export interface GeoIPLocation extends LocationRecord {
 
 export interface IpAddress extends CityResponse {
   readonly risk: number;
-  readonly country: GeoIPCountry;
-  readonly location: GeoIPLocation;
+  readonly country?: GeoIPCountry;
+  readonly location?: GeoIPLocation;
 }
 
 export interface CreditCardIssuer {


### PR DESCRIPTION
PR #48 saw an issue where "incomplete" insights responses were throwing an error.  This PR modifies our insights model to check if the response contains IP address country and location data before it assigns the data to the model.

Typescript 2.7's optional chaining would've made this more succinct, but alas it isn't ready for production yet.