### PR TITLE
Upgrade GeoIP2-node to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "version": "yarn build:docs && yarn deploy:docs"
   },
   "dependencies": {
-    "@maxmind/geoip2-node": "^1.6.0",
+    "@maxmind/geoip2-node": "^2.0.1",
     "camelcase-keys": "^6.0.1",
     "maxmind": "^4.1.0",
     "snakecase-keys": "^3.1.0",

--- a/src/response/models/insights.spec.ts
+++ b/src/response/models/insights.spec.ts
@@ -10,7 +10,7 @@ describe('Insights()', () => {
 
     const model = new Insights(input);
 
-    expect(model.ipAddress.country.isHighRisk).toBeUndefined();
+    expect(model.ipAddress.country).toBeUndefined();
   });
 
   it('handles empty location responses', () => {
@@ -20,7 +20,7 @@ describe('Insights()', () => {
 
     const model = new Insights(input);
 
-    expect(model.ipAddress.location.localTime).toBeUndefined();
+    expect(model.ipAddress.location).toBeUndefined();
   });
 
   it('allows /email/domain/first_seen to be accessed', () => {

--- a/src/response/models/insights.ts
+++ b/src/response/models/insights.ts
@@ -68,13 +68,13 @@ export default class Insights extends Score {
   ): records.IpAddress {
     const insights = new GeoInsights(response.ip_address) as records.IpAddress;
 
-    insights.country.isHighRisk = response.ip_address.country
-      ? response.ip_address.country.is_high_risk
-      : undefined;
+    if (insights.country && response.ip_address.country) {
+      insights.country.isHighRisk = response.ip_address.country.is_high_risk;
+    }
 
-    insights.location.localTime = response.ip_address.location
-      ? response.ip_address.location.local_time
-      : undefined;
+    if (insights.location && response.ip_address.location) {
+      insights.location.localTime = response.ip_address.location.local_time;
+    }
 
     insights.risk = response.ip_address.risk;
 

--- a/src/response/records.ts
+++ b/src/response/records.ts
@@ -48,11 +48,11 @@ export interface IpAddress extends Insights {
    * Country object for the requested IP address. This record represents the
    * country where MaxMind believes the IP is located.
    */
-  readonly country: GeoIPCountry;
+  readonly country?: GeoIPCountry;
   /**
    * Location object for the requested IP address.
    */
-  readonly location: GeoIPLocation;
+  readonly location?: GeoIPLocation;
   /**
    * Gets the MaxMind record containing data related to your account
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,10 +479,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@maxmind/geoip2-node@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-1.6.0.tgz#526da73970a807a916ba15b3aa4c0b5247113348"
-  integrity sha512-3+AixEbxcYRcSEzT4t1Zgs2O00tjtFjH8XFz1zOI3NISDzVrYCL5cc59Nq81bqp+zy/cIex3IGOyXniCPjGgsg==
+"@maxmind/geoip2-node@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-2.0.1.tgz#21ea31be058caa80c23924e6c37d8f479ddd3ede"
+  integrity sha512-6V3Y6jEAazQbwVi1M22C/jD6WsITMdr+hVVzCPk5TTB2h3wJYbc4orEGVsvdbZZRr8j8YsWHr6vLNqMiMzK4mQ==
   dependencies:
     camelcase-keys "^6.0.1"
     ip6addr "^0.2.3"


### PR DESCRIPTION
### Contains a breaking change
`insights` geolocation values return `undefined` instead of `{}` when empty