### PR TITLE
Yarn upgrade + Release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - run: yarn install
       - run: yarn test --coverage
       - run: yarn build
+      - run: yarn build:docs
       - run: yarn link
       - run: yarn
         working-directory: e2e/js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 CHANGELOG
 =========
 
-3.0.0
+3.0.0 (2020-01-19)
 ------------------
 
 * Added `ApplePay` and `ApsPayments` to the `Processor` enum.
 * Added additional normalizing of the email address when it is sent as an
   MD5 hash instead of plain text.
+* Upgrade yarn dependencies
 
 ### Breaking change
 The email address field is now sent to the web service in plain text unless
@@ -15,6 +16,11 @@ option sends the MD5 hash of the address to the web service instead.
 Previously the address was always sent as an MD5 hash. The new default
 behavior matches that of other official minFraud API clients. Note the
 email domain is always sent in plain text.
+
+2.1.0 (2020-01-11)
+------------------
+
+* Upgrade yarn dependencies
 
 2.0.0 (2020-11-09)
 ------------------

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "build:docs": "rimraf docs && typedoc --out docs --exclude \"**/*.spec.ts\" --mode file --readme README.md",
+    "build:docs": "rimraf docs && typedoc src/index.ts --out docs --exclude \"**/*.spec.ts\" --readme README.md",
     "deploy:docs": "gh-pages -d docs",
     "lint": "tslint -p ./tsconfig.lint.json -t stylish",
     "prettier:ts": "prettier --parser typescript --single-quote true --trailing-comma es5 --write 'src/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@types/jest": "^26.0.0",
     "@types/lodash.clonedeep": "^4.5.4",
-    "@types/nock": "^11.1.0",
     "@types/node": "^14.0.5",
     "@types/snakecase-keys": "^2.1.0",
     "@types/validator": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,10 @@
     }
   },
   "lint-staged": {
-    "*.json": ["prettier --parser json --write", "git add"],
+    "*.json": ["prettier --parser json --write"],
     "*.ts": [
       "prettier --parser typescript --single-quote true --trailing-comma es5 --write",
-      "tslint -p tsconfig.lint.json -t stylish",
-      "git add"
+      "tslint -p tsconfig.lint.json -t stylish"
     ]
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,13 +652,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/nock@^11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-11.1.0.tgz#0a8c1056a31ba32a959843abccf99626dd90a538"
-  integrity sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
-  dependencies:
-    nock "*"
-
 "@types/node@*", "@types/node@^14.0.5":
   version "14.14.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
@@ -3971,7 +3964,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nock@*, nock@^13.0.2:
+nock@^13.0.2:
   version "13.0.5"
   resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.5.tgz#a618c6f86372cb79fac04ca9a2d1e4baccdb2414"
   integrity sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,9 +466,9 @@
     chalk "^4.0.0"
 
 "@maxmind/geoip2-node@^2.0.1":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-2.1.0.tgz#9b311ee80b265daf5f59b9a69bb70d6f7e0be15f"
-  integrity sha512-mN7YRe1gwEt0PXC9gv3xChRvsFq226HgngEadTUtpK84+R8t5bc5IFiC4YJz+ogIpWBUuQBeekqpuWcWT4HYdg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-2.1.1.tgz#03bc08633d63a08789e0d891e5effb8ad8413634"
+  integrity sha512-vG+GeNMVb9Z27Y9V1tte2ExgcYZ+FCLtOOynbypyP5Pe7JGL0QI7NCRKAu9zgaQ7KxSKbJG8etb+r/CSEfElFw==
   dependencies:
     camelcase-keys "^6.0.1"
     ip6addr "^0.2.3"
@@ -519,9 +519,9 @@
   integrity sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==
 
 "@sinonjs/commons@^1.7.0":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
-  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
+  integrity sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
   dependencies:
     type-detect "4.0.8"
 
@@ -643,9 +643,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.167"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
-  integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/minimist@^1.2.0":
   version "1.2.1"
@@ -1951,9 +1951,9 @@ fast-deep-equal@^3.1.1:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.1.1:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
-  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -4364,9 +4364,9 @@ parent-module@^1.0.0:
     callsites "^3.0.0"
 
 parse-json@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"
-  integrity sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     error-ex "^1.3.1"


### PR DESCRIPTION
* Upgrades Yarn dependencies
* Fixes `typedocs` build script and test for building docs
* Removes third-party typings for Nock in favor of first-party