### PR TITLE
Add support for 8 digit IINs and 2 digit last_digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,16 @@ CHANGELOG
   `lastDigits`/`last4digits` also now supports two digit values in
   addition to the previous four digit values.
 * Eight digit `/credit_card/issuerIdNumber` inputs are now supported in
-  addition to the previously accepted six digit `issuerIdNumber`. If you
-  send six digits for the `issuerIdNumber`, you should send the last four
-  digits for `lastDigits`. If you send eight digits for `issuerIdNumber`
-  you should send the last two digits for `lastDigits`.
+  addition to the previously accepted six digit `issuerIdNumber`. In most
+  cases, you should send the last four digits for `lastDigits`. If you send
+  an `issuerIdNumber` that contains an eight digit IIN, and if the credit
+  card brand is not one of the following, you should send the last two digits
+  for `lastDigits`:
+  * `Discover`
+  * `JCB`
+  * `Mastercard`
+  * `UnionPay`
+  * `Visa`
 
 4.3.0 (2021-08-31)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,16 +22,15 @@ CHANGELOG
   `response.ipAddress.traits.mobileCountryCode` and
   `response.ipAddress.traits.mobileNetworkCode`. We expect this data to be
   available by late January, 2022.
-* The `/credit_card/last4digits` input has been deprecated in favor of
-  `/credit_card/lastDigits` and will be removed in a future release.
-  `lastDigits`/`last4digits` also now supports two digit values in
-  addition to the previous four digit values.
-* Eight digit `/credit_card/issuerIdNumber` inputs are now supported in
-  addition to the previously accepted six digit `issuerIdNumber`. In most
-  cases, you should send the last four digits for `lastDigits`. If you send
-  an `issuerIdNumber` that contains an eight digit IIN, and if the credit
-  card brand is not one of the following, you should send the last two digits
-  for `lastDigits`:
+* `creditCard.last4digits` has been deprecated in favor of `creditCard.lastDigits`
+   and will be removed in a future release. `lastDigits`/`last4digits` also now
+   supports two digit values in addition to the previous four digit values.
+* Eight digit `creditCard.issuerIdNumber` inputs are now supported in addition to
+  the previously accepted six digit `issuerIdNumber`. In most cases, you should
+  send the last four digits for `creditCard.lastDigits`. If you send a
+  `issuerIdNumber` that contains an eight digit IIN, and if the credit card brand
+  is not one of the following, you should send the last two digits for
+  `lastDigits`:
   * `Discover`
   * `JCB`
   * `Mastercard`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ CHANGELOG
   `response.ipAddress.traits.mobileCountryCode` and
   `response.ipAddress.traits.mobileNetworkCode`. We expect this data to be
   available by late January, 2022.
+* The `/credit_card/last4digits` input has been deprecated in favor of
+  `/credit_card/lastDigits` and will be removed in a future release.
+  `lastDigits`/`last4digits` also now supports two digit values in
+  addition to the previous four digit values.
+* Eight digit `/credit_card/issuerIdNumber` inputs are now supported in
+  addition to the previously accepted six digit `issuerIdNumber`s. If you
+  send six digits for the `issuerIdNumber`, you should send the last four
+  digits for `lastDigits`. If you send eight digits for `issuerIdNumber`
+  you should send the last two digits for `lastDigits`.
 
 4.3.0 (2021-08-31)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ CHANGELOG
   `lastDigits`/`last4digits` also now supports two digit values in
   addition to the previous four digit values.
 * Eight digit `/credit_card/issuerIdNumber` inputs are now supported in
-  addition to the previously accepted six digit `issuerIdNumber`s. If you
+  addition to the previously accepted six digit `issuerIdNumber`. If you
   send six digits for the `issuerIdNumber`, you should send the last four
   digits for `lastDigits`. If you send eight digits for `issuerIdNumber`
   you should send the last two digits for `lastDigits`.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ try {
       bankPhoneNumber: '123-123-1234',
       cvvResult: 'B',
       issuerIdNumber: '411111',
-      last4digits: '1234',
+      lastDigits: '1234',
       token: 'a_token',
       was3DSecureSuccessful: true,
     }),

--- a/src/request/credit-card.spec.ts
+++ b/src/request/credit-card.spec.ts
@@ -10,10 +10,10 @@ describe('CreditCard()', () => {
     ${'issuerIdNumber is too short'}                    | ${'issuerIdNumber'} | ${'12345'}
     ${'issuerIdNumber has letters'}                     | ${'issuerIdNumber'} | ${'12345a'}
     ${'issuerIdNumber has non-alphanumeric characters'} | ${'issuerIdNumber'} | ${'12345!'}
-    ${'last4digits is too long'}                        | ${'last4digits'}    | ${'12345'}
-    ${'last4digits is too short'}                       | ${'last4digits'}    | ${'123'}
-    ${'last4digits has letters'}                        | ${'last4digits'}    | ${'12a'}
-    ${'last4digits has non-alphanumeric characters'}    | ${'last4digits'}    | ${'154!'}
+    ${'lastDigits is too long'}                         | ${'lastDigits'}     | ${'12345'}
+    ${'lastDigits is too short'}                        | ${'lastDigits'}     | ${'123'}
+    ${'lastDigits has letters'}                         | ${'lastDigits'}     | ${'12a'}
+    ${'lastDigits has non-alphanumeric characters'}     | ${'lastDigits'}     | ${'154!'}
     ${'token is a PAN'}                                 | ${'token'}          | ${'4485921507912924'}
     ${'token is numbers'}                               | ${'token'}          | ${'432312'}
     ${'token is some string phrase'}                    | ${'token'}          | ${'this is invalid'}
@@ -54,5 +54,25 @@ describe('CreditCard()', () => {
           was3DSecureSuccessful: true,
         })
     ).not.toThrow();
+  });
+
+  it('last4digits getter aliases lastDigits', () => {
+    const cc = new CreditCard({
+      issuerIdNumber: '411111',
+      lastDigits: '1234',
+    });
+
+    expect(cc.lastDigits).toBe('1234');
+    expect(cc.last4digits).toBe(cc.lastDigits);
+  });
+
+  it('last4digits setter aliases lastDigits', () => {
+    const cc = new CreditCard({
+      issuerIdNumber: '411111',
+    });
+    cc.last4digits = '1234';
+
+    expect(cc.lastDigits).toBe('1234');
+    expect(cc.last4digits).toBe(cc.lastDigits);
   });
 });

--- a/src/request/credit-card.ts
+++ b/src/request/credit-card.ts
@@ -7,9 +7,15 @@ export interface CreditCardProps {
    */
   issuerIdNumber?: string;
   /**
-   * The last four digits of the credit card number.
+   * The last digits of the credit card number.
+   *
+   * @deprecated Use lastDigits instead
    */
   last4digits?: string;
+  /**
+   * The last digits of the credit card number.
+   */
+  lastDigits?: string;
   /**
    * A token uniquely identifying the card. This should not be the actual
    * credit card number.
@@ -50,8 +56,8 @@ export interface CreditCardProps {
 }
 
 const singleChar = /^[A-Za-z0-9]$/;
-const issuerIdNumberRegex = /^[0-9]{6}$/;
-const last4Regex = /^[0-9]{4}$/;
+const issuerIdNumberRegex = /^(?:[0-9]{6}|[0-9]{8})$/;
+const lastDigitsRegex = /^(?:[0-9]{2}|[0-9]{4})$/;
 const tokenRegex = /^(?![0-9]{1,19}$)[\u0021-\u007E]{1,255}$/;
 
 /**
@@ -60,8 +66,8 @@ const tokenRegex = /^(?![0-9]{1,19}$)[\u0021-\u007E]{1,255}$/;
 export default class CreditCard implements CreditCardProps {
   /** @inheritDoc CreditCardProps.issuerIdNumber */
   public issuerIdNumber?: string;
-  /** @inheritDoc CreditCardProps.last4digits */
-  public last4digits?: string;
+  /** @inheritDoc CreditCardProps.lastDigits */
+  public lastDigits?: string;
   /** @inheritDoc CreditCardProps.token */
   public token?: string;
   /** @inheritDoc CreditCardProps.bankName */
@@ -105,12 +111,31 @@ export default class CreditCard implements CreditCardProps {
       );
     }
 
+    if (creditCard.last4digits != null) {
+      creditCard.lastDigits = creditCard.last4digits;
+    }
+
+    if (creditCard.lastDigits != null) {
+      creditCard.last4digits = creditCard.lastDigits;
+    }
+
     if (
-      creditCard.last4digits != null &&
-      !last4Regex.test(creditCard.last4digits)
+      creditCard.lastDigits != null &&
+      !lastDigitsRegex.test(creditCard.lastDigits)
     ) {
       throw new ArgumentError(
-        `The last 4 credit card digits (last4digits) ${creditCard.last4digits} are of the wrong format.`
+        `The last credit card digits (lastDigits) ${creditCard.lastDigits} are of the wrong format.`
+      );
+    }
+
+    if (
+      creditCard.issuerIdNumber != null &&
+      creditCard.lastDigits != null &&
+      creditCard.issuerIdNumber.length === 8 &&
+      creditCard.lastDigits.length !== 2
+    ) {
+      throw new ArgumentError(
+        `The last credit card digits (lastDigits) ${creditCard.lastDigits} are of the wrong format. An eight digit issuerIdNumber requires a two digit value for lastDigit.`
       );
     }
 
@@ -121,5 +146,21 @@ export default class CreditCard implements CreditCardProps {
     }
 
     Object.assign(this, creditCard);
+  }
+
+  /** Get the last digits of the credit card number.
+   *
+   * @deprecated Use lastDigits instead
+   */
+  public get last4digits() {
+    return this.lastDigits!;
+  }
+
+  /** Set the last digits of the credit card number.
+   *
+   * @deprecated Use lastDigits instead
+   */
+  public set last4digits(lastDigits: string) {
+    this.lastDigits = lastDigits;
   }
 }

--- a/src/request/credit-card.ts
+++ b/src/request/credit-card.ts
@@ -115,10 +115,6 @@ export default class CreditCard implements CreditCardProps {
       creditCard.lastDigits = creditCard.last4digits;
     }
 
-    if (creditCard.lastDigits != null) {
-      creditCard.last4digits = creditCard.lastDigits;
-    }
-
     if (
       creditCard.lastDigits != null &&
       !lastDigitsRegex.test(creditCard.lastDigits)

--- a/src/request/credit-card.ts
+++ b/src/request/credit-card.ts
@@ -153,14 +153,14 @@ export default class CreditCard implements CreditCardProps {
    * @deprecated Use lastDigits instead
    */
   public get last4digits() {
-    return this.lastDigits!;
+    return this.lastDigits;
   }
 
   /** Set the last digits of the credit card number.
    *
    * @deprecated Use lastDigits instead
    */
-  public set last4digits(lastDigits: string) {
+  public set last4digits(lastDigits: string | undefined) {
     this.lastDigits = lastDigits;
   }
 }

--- a/src/request/credit-card.ts
+++ b/src/request/credit-card.ts
@@ -124,17 +124,6 @@ export default class CreditCard implements CreditCardProps {
       );
     }
 
-    if (
-      creditCard.issuerIdNumber != null &&
-      creditCard.lastDigits != null &&
-      creditCard.issuerIdNumber.length === 8 &&
-      creditCard.lastDigits.length !== 2
-    ) {
-      throw new ArgumentError(
-        `The last credit card digits (lastDigits) ${creditCard.lastDigits} are of the wrong format. An eight digit issuerIdNumber requires a two digit value for lastDigit.`
-      );
-    }
-
     if (creditCard.token != null && !tokenRegex.test(creditCard.token)) {
       throw new ArgumentError(
         `The credit card token (token) ${creditCard.token} was invalid. Tokens must be non-space ASCII printable characters. If the token consists of all digits, it must be more than 19 digits.`

--- a/src/request/transaction.spec.ts
+++ b/src/request/transaction.spec.ts
@@ -326,7 +326,7 @@ describe('Transaction()', () => {
           }).toString()
         );
 
-        expect(test.credit_card).toHaveProperty('last_4_digits', '1234');
+        expect(test.credit_card).toHaveProperty('last_digits', '1234');
       });
 
       test('null value is mapped', () => {
@@ -341,7 +341,7 @@ describe('Transaction()', () => {
           }).toString()
         );
 
-        expect(test.credit_card).toHaveProperty('last_4_digits', null);
+        expect(test.credit_card).toHaveProperty('last_digits', null);
       });
     });
 

--- a/src/request/transaction.spec.ts
+++ b/src/request/transaction.spec.ts
@@ -266,9 +266,7 @@ describe('Transaction()', () => {
 
       expect(test.toString()).toContain(deviceString);
 
-      expect(test.toString()).toContain(
-        '"credit_card":{"last_4_digits":"1234"}'
-      );
+      expect(test.toString()).toContain('"credit_card":{"last_digits":"1234"}');
     });
 
     it('it handles optional order field', () => {
@@ -413,6 +411,65 @@ describe('Transaction()', () => {
 
         expect(test.shipping).toHaveProperty('address_2', null);
       });
+    });
+  });
+
+  describe('6 or 8 digit iins and 2 or 4 digit lastDigits', () => {
+    it('it handles 8 digit iins with 2 digit lastDigits', () => {
+      const test = new Transaction({
+        creditCard: new CreditCard({
+          issuerIdNumber: '12345678',
+          lastDigits: '12',
+        }),
+        device: new Device({
+          ipAddress: '1.1.1.1',
+          sessionAge: 100,
+        }),
+      });
+
+      expect(isJSON(test.toString())).toBe(true);
+
+      expect(test.toString()).toContain(
+        '"credit_card":{"issuer_id_number":"12345678","last_digits":"12"}'
+      );
+    });
+
+    it('it handles 8 digit iins with 4 digit lastDigits', () => {
+      const test = new Transaction({
+        creditCard: new CreditCard({
+          issuerIdNumber: '12345678',
+          lastDigits: '1234',
+        }),
+        device: new Device({
+          ipAddress: '1.1.1.1',
+          sessionAge: 100,
+        }),
+      });
+
+      expect(isJSON(test.toString())).toBe(true);
+
+      expect(test.toString()).toContain(
+        '"credit_card":{"issuer_id_number":"12345678","last_digits":"1234"}'
+      );
+    });
+
+    it('it handles 6 digit iins with 2 digit lastDigits', () => {
+      const test = new Transaction({
+        creditCard: new CreditCard({
+          issuerIdNumber: '123456',
+          lastDigits: '12',
+        }),
+        device: new Device({
+          ipAddress: '1.1.1.1',
+          sessionAge: 100,
+        }),
+      });
+
+      expect(isJSON(test.toString())).toBe(true);
+
+      expect(test.toString()).toContain(
+        '"credit_card":{"issuer_id_number":"123456","last_digits":"12"}'
+      );
     });
   });
 });

--- a/src/request/transaction.spec.ts
+++ b/src/request/transaction.spec.ts
@@ -315,7 +315,7 @@ describe('Transaction()', () => {
   });
 
   describe('key casing conversion', () => {
-    describe('`creditCard.last4digits` => `creditCard.last_4_digits`', () => {
+    describe('`creditCard.lastDigits/last4digits` => `creditCard.lastDigits`', () => {
       test('typed value is mapped', () => {
         const test = JSON.parse(
           new Transaction({
@@ -338,6 +338,34 @@ describe('Transaction()', () => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore explicit null
             creditCard: new CreditCard({ last4digits: null }),
+          }).toString()
+        );
+
+        expect(test.credit_card).toHaveProperty('last_digits', null);
+      });
+
+      test('typed value is mapped', () => {
+        const test = JSON.parse(
+          new Transaction({
+            device: new Device({
+              ipAddress: '1.1.1.1',
+            }),
+            creditCard: new CreditCard({ lastDigits: '1234' }),
+          }).toString()
+        );
+
+        expect(test.credit_card).toHaveProperty('last_digits', '1234');
+      });
+
+      test('null value is mapped', () => {
+        const test = JSON.parse(
+          new Transaction({
+            device: new Device({
+              ipAddress: '1.1.1.1',
+            }),
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore explicit null
+            creditCard: new CreditCard({ lastDigits: null }),
           }).toString()
         );
 

--- a/src/request/transaction.ts
+++ b/src/request/transaction.ts
@@ -117,16 +117,12 @@ export default class Transaction {
   private sanitizeKeys() {
     const sanitized = Object.assign({}, this) as any;
 
-    if (sanitized.creditCard != null) {
-      if (sanitized.creditCard.last4digits != null) {
-        sanitized.creditCard.last_digits = this.creditCard!.last4digits;
-        delete sanitized.creditCard.last4digits;
-      }
-
-      if (sanitized.creditCard.lastDigits != null) {
-        sanitized.creditCard.last_digits = this.creditCard!.lastDigits;
-        delete sanitized.creditCard.lastDigits;
-      }
+    if (
+      sanitized.creditCard &&
+      Object.prototype.hasOwnProperty.call(sanitized.creditCard, 'lastDigits')
+    ) {
+      sanitized.creditCard.last_digits = sanitized.creditCard.lastDigits;
+      delete sanitized.creditCard.lastDigits;
     }
 
     if (

--- a/src/request/transaction.ts
+++ b/src/request/transaction.ts
@@ -117,12 +117,16 @@ export default class Transaction {
   private sanitizeKeys() {
     const sanitized = Object.assign({}, this) as any;
 
-    if (
-      sanitized.creditCard &&
-      Object.prototype.hasOwnProperty.call(sanitized.creditCard, 'last4digits')
-    ) {
-      sanitized.creditCard.last_4_digits = sanitized.creditCard.last4digits;
-      delete sanitized.creditCard.last4digits;
+    if (sanitized.creditCard != null) {
+      if (sanitized.creditCard.last4digits != null) {
+        sanitized.creditCard.last_digits = this.creditCard!.last4digits;
+        delete sanitized.creditCard.last4digits;
+      }
+
+      if (sanitized.creditCard.lastDigits != null) {
+        sanitized.creditCard.last_digits = this.creditCard!.lastDigits;
+        delete sanitized.creditCard.lastDigits;
+      }
     }
 
     if (


### PR DESCRIPTION
Previously the issuerIdNumber was expected to be 6 digits and
last4digits to be 4 digits. This changes the validation to also
allow for 8 digit issuerIdNumbers and 2 digit last4digits.

Additionally last4digits has been deprecated in favor of the more
appropriately named lastDigits.