### PR TITLE
Ignore Dependabot pushes for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,8 @@ name: "Code scanning - action"
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   schedule:
     - cron: '0 16 * * 2'
 


### PR DESCRIPTION
See [this doc](https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push).
