### PR TITLE
Fix was3DSecureSuccessful conversion to snakecase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ------------------
 
 * Added `ShopifyPayments` to the `Processor` enum.
+* Fix `creditCard.was3DSecureSuccessful` snakecase conversion.
 
 4.5.0 (2022-03-28)
 ------------------

--- a/src/request/transaction.spec.ts
+++ b/src/request/transaction.spec.ts
@@ -255,6 +255,7 @@ describe('Transaction()', () => {
       const test = new Transaction({
         creditCard: new CreditCard({
           last4digits: '1234',
+          was3DSecureSuccessful: true,
         }),
         device: new Device({
           ipAddress: '1.1.1.1',
@@ -266,7 +267,9 @@ describe('Transaction()', () => {
 
       expect(test.toString()).toContain(deviceString);
 
-      expect(test.toString()).toContain('"credit_card":{"last_digits":"1234"}');
+      expect(test.toString()).toContain(
+        '"credit_card":{"last_digits":"1234","was_3d_secure_successful":true}'
+      );
     });
 
     it('it handles optional order field', () => {

--- a/src/request/transaction.ts
+++ b/src/request/transaction.ts
@@ -120,14 +120,6 @@ export default class Transaction {
     const sanitized = Object.assign({}, this) as any;
 
     if (
-      sanitized.creditCard &&
-      Object.prototype.hasOwnProperty.call(sanitized.creditCard, 'lastDigits')
-    ) {
-      sanitized.creditCard.last_digits = sanitized.creditCard.lastDigits;
-      delete sanitized.creditCard.lastDigits;
-    }
-
-    if (
       sanitized.billing &&
       Object.prototype.hasOwnProperty.call(sanitized.billing, 'address2')
     ) {
@@ -141,6 +133,18 @@ export default class Transaction {
     ) {
       sanitized.shipping.address_2 = sanitized.shipping.address2;
       delete sanitized.shipping.address2;
+    }
+
+    if (
+      sanitized.creditCard &&
+      Object.prototype.hasOwnProperty.call(
+        sanitized.creditCard,
+        'was3DSecureSuccessful'
+      )
+    ) {
+      sanitized.creditCard.was_3d_secure_successful =
+        sanitized.creditCard.was3DSecureSuccessful;
+      delete sanitized.creditCard.was3DSecureSuccessful;
     }
 
     return sanitized;


### PR DESCRIPTION
#### Expected
`credit_card.was_3d_secure_successful` is sent to minFraud endpoint.

#### Actual
`credit_card.was3_d_secure_successful` is sent to minFraud endpoint.
