### PR TITLE
Revert "Bump snakecase-keys from 5.4.6 to 5.4.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5421,9 +5421,9 @@
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.7.tgz",
-      "integrity": "sha512-li/JvhIBDTbualWBSlUJoHws/kVqMYN9GSw//NyatvoAWBppiGRJVOOniMcRa/PNN5FCwOTYMoZT/SJ2IuBUBw==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.6.tgz",
+      "integrity": "sha512-7ipeNts8YTLbx/6zIaT1mQGrHG2vK+0TjywPD79QzIDJDcvNXBLX7DXQOt6by4DFdncu8lDPc+QHKHemtDEoQg==",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
@@ -10074,9 +10074,9 @@
       }
     },
     "snakecase-keys": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.7.tgz",
-      "integrity": "sha512-li/JvhIBDTbualWBSlUJoHws/kVqMYN9GSw//NyatvoAWBppiGRJVOOniMcRa/PNN5FCwOTYMoZT/SJ2IuBUBw==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.6.tgz",
+      "integrity": "sha512-7ipeNts8YTLbx/6zIaT1mQGrHG2vK+0TjywPD79QzIDJDcvNXBLX7DXQOt6by4DFdncu8lDPc+QHKHemtDEoQg==",
       "requires": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",


### PR DESCRIPTION
Reverts maxmind/minfraud-api-node#1121

This should not have been merged as it breaks the build.