### PR TITLE
Fix flaky WebServiceClient error-handling tests

### DIFF
--- a/src/webServiceClient.spec.ts
+++ b/src/webServiceClient.spec.ts
@@ -902,6 +902,12 @@ describe('WebServiceClient', () => {
 
   describe('error handling', () => {
     afterEach(() => {
+      // `handles timeouts` below uses `.delayConnection(100)` with a 10ms
+      // client timeout. The client aborts at 10ms, but nock's pending reply
+      // timer keeps ticking and can fire in a later test — producing a
+      // spurious `InterceptorError: ... the request has already been
+      // handled`. Abort those timers so they can't bleed across tests.
+      nock.abortPendingRequests();
       nock.cleanAll();
     });
 


### PR DESCRIPTION
The `handles timeouts` test registers a nock interceptor with a 100ms connection delay while the client's own timeout is 10ms. The client aborts at 10ms, but nock's pending setTimeout for the delayed reply keeps ticking and could fire during a later test, producing a spurious `InterceptorError: ... the request has already been handled`.

Call `nock.abortPendingRequests()` alongside `cleanAll()` in afterEach so that leaked timer can't bleed into the next test.