### PR TITLE
Add `CLEAR` to the `Tag` enum (STF-190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
   for explicit device linking. You may provide this by providing
   `trackingToken` to `Device`.
 * Added `FatZebra` to the `Processor` enum.
+* Added `CLEAR` to the `Tag` enum for use with the Report Transaction API.
 
 8.3.0 (2026-01-20)
 ------------------

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -207,6 +207,7 @@ export enum Processor {
 
 export enum Tag {
   CHARGEBACK = 'chargeback',
+  CLEAR = 'clear',
   NOT_FRAUD = 'not_fraud',
   SPAM_OR_ABUSE = 'spam_or_abuse',
   SUSPECTED_FRAUD = 'suspected_fraud',

--- a/src/request/transaction-report.spec.ts
+++ b/src/request/transaction-report.spec.ts
@@ -60,4 +60,13 @@ describe('Device()', () => {
       });
     }).not.toThrow();
   });
+
+  it('accepts the clear tag', () => {
+    expect(() => {
+      new TransactionReport({
+        ipAddress: '1.1.1.1',
+        tag: Tag.CLEAR,
+      });
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `CLEAR = 'clear'` to the `Tag` enum in `src/constants.ts`.
- Adds a test case exercising `Tag.CLEAR` in `transaction-report.spec.ts`.
- Appends a bullet to the existing unreleased `8.4.0` entry in `CHANGELOG.md`.

The `clear` tag retracts a previously reported fraud report on a transaction
(restoring its label to "unknown", distinct from the positive `not_fraud`
signal). Backend support shipped in STF-15; this adds SDK support per STF-190.

Linear: https://linear.app/maxmind/issue/STF-190

## Test plan

- [x] `npm test -- src/request/transaction-report.spec.ts` — 7 passed
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)