### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ await client.reportTransaction(report);
 
 **Exception:** Use plain `string` only when the API documentation explicitly states "additional values may be added in the future" AND you want to allow any string value (e.g., `phone.numberType`).
 
-#### 6. **GeoIP2 Integration**
+#### 6. **GeoIP Integration**
 
 The Insights and Factors responses include IP geolocation data from the @maxmind/geoip2-node library:
 ```typescript
@@ -331,7 +331,7 @@ try {
 }
 ```
 
-### Problem: GeoIP2 Type Conflicts
+### Problem: GeoIP Type Conflicts
 
 The IP address data comes from @maxmind/geoip2-node and needs augmentation.
 

--- a/src/response/models/factors.ts
+++ b/src/response/models/factors.ts
@@ -11,7 +11,7 @@ export default class Factors extends Insights {
   public readonly riskScoreReasons?: records.RiskScoreReason[];
 
   /**
-   * An object containing GeoIP2 and minFraud Insights information about the IP
+   * An object containing GeoIP and minFraud Insights information about the IP
    * address.
    *
    * @deprecated replaced by {@link riskScoreReasons}.

--- a/src/response/models/insights.ts
+++ b/src/response/models/insights.ts
@@ -31,7 +31,7 @@ export default class Insights extends Score {
    */
   public readonly email?: records.Email;
   /**
-   * An object containing GeoIP2 and minFraud Insights information about the IP address.
+   * An object containing GeoIP and minFraud Insights information about the IP address.
    */
   public readonly ipAddress?: records.IpAddress;
   /**

--- a/src/response/records.ts
+++ b/src/response/records.ts
@@ -24,7 +24,7 @@ export interface ScoreIpAddress {
 }
 
 /**
- * A subclass of the GeoIP2 Country model with minFraud-specific additions.
+ * A subclass of the GeoIP Country model with minFraud-specific additions.
  */
 export interface GeoIPCountry extends CountryRecord {
   /**
@@ -37,7 +37,7 @@ export interface GeoIPCountry extends CountryRecord {
 }
 
 /**
- * A subclass of the GeoIP2 Location model with minFraud-specific additions.
+ * A subclass of the GeoIP Location model with minFraud-specific additions.
  */
 export interface GeoIPLocation extends LocationRecord {
   /**
@@ -64,7 +64,7 @@ export interface IpRiskReasons {
 }
 
 /**
- * Model for minFraud GeoIP2 Insights data.
+ * Model for minFraud GeoIP Insights data.
  */
 export interface IpAddress extends Insights {
   /**


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)