### PR TITLE
Add residential proxy data to anonymizer object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 CHANGELOG
 =========
 
+9.1.0 (unreleased)
+------------------
+
+* A new `residential` property has been added to the `anonymizer` object on
+  `IpAddress`. This contains residential proxy data for the network and is
+  available from the minFraud Insights and Factors web services only. It may
+  be populated even when no other `anonymizer` properties are set. The
+  `residential` object includes the following properties:
+  * `confidence`: A score (1-99) representing MaxMind's confidence that the
+    network is part of an actively used residential proxy
+  * `networkLastSeen`: The last day (YYYY-MM-DD) the network was sighted in
+    our analysis of residential proxies
+  * `providerName`: The name of the residential proxy provider associated
+    with the network
+* This release requires `@maxmind/geoip2-node` 7.1.0 or greater, which adds
+  the `residential` property to the `AnonymizerRecord` type. The
+  `@maxmind/geoip2-node` dependency will be bumped to `^7.1.0` once that
+  version is released.
+
 9.0.0 (2026-06-29)
 ------------------
 

--- a/fixtures/insights.json
+++ b/fixtures/insights.json
@@ -34,7 +34,12 @@
           "is_residential_proxy": false,
           "is_tor_exit_node": true,
           "network_last_seen": "2025-01-15",
-          "provider_name": "TestVPN"
+          "provider_name": "TestVPN",
+          "residential": {
+            "confidence": 82,
+            "network_last_seen": "2026-05-11",
+            "provider_name": "quickshift"
+          }
         },
         "city": {
           "confidence": 25,

--- a/src/response/models/insights.spec.ts
+++ b/src/response/models/insights.spec.ts
@@ -76,6 +76,11 @@ describe('Insights()', () => {
       isTorExitNode: true,
       networkLastSeen: '2025-01-15',
       providerName: 'TestVPN',
+      residential: {
+        confidence: 82,
+        networkLastSeen: '2026-05-11',
+        providerName: 'quickshift',
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

Surfaces the new `residential` sub-object of the `anonymizer` object in the minFraud Insights and Factors `ip_address` response. The models reuse the GeoIP2 library's Anonymizer record, so this is a fixtures/tests/changelog change; the field flows through via the dependency.

Depends on maxmind/GeoIP2-node#1738. At release time the `@maxmind/geoip2-node` dependency should be bumped to `^7.1.0` once published (the data flows through at runtime even on 7.0.0 since parsing is generic, but the types require 7.1.0).

## Testing

npm test 218/218 and npm run lint clean against published 7.0.0; re-verified against the PR branch via a temporary file: dependency (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)