### PR TITLE
Expand email alias domain lists

### DIFF
--- a/src/request/email.spec.ts
+++ b/src/request/email.spec.ts
@@ -225,6 +225,11 @@ describe('Email()', () => {
       domain: 'user.fastmail.com',
     },
     {
+      email: 'alias@user.fastmail.ca',
+      md5: md5('user@fastmail.ca'),
+      domain: 'user.fastmail.ca',
+    },
+    {
       email: 'foo@bar.example.com',
       md5: md5('foo@bar.example.com'),
       domain: 'bar.example.com',
@@ -233,6 +238,11 @@ describe('Email()', () => {
       email: 'foo-bar@ymail.com',
       md5: md5('foo@ymail.com'),
       domain: 'ymail.com',
+    },
+    {
+      email: 'test-alias@myyahoo.com',
+      md5: md5('test@myyahoo.com'),
+      domain: 'myyahoo.com',
     },
     {
       email: 'foo@example.com.com',

--- a/src/request/email.ts
+++ b/src/request/email.ts
@@ -168,6 +168,7 @@ export default class Email implements EmailProps {
     'fastemailer.com': true,
     'fastest.cc': true,
     'fastimap.com': true,
+    'fastmail.ca': true,
     'fastmail.cn': true,
     'fastmail.co.uk': true,
     'fastmail.com': true,
@@ -261,6 +262,7 @@ export default class Email implements EmailProps {
   };
 
   private static readonly yahooDomains: { [key: string]: boolean } = {
+    'myyahoo.com': true,
     'y7mail.com': true,
     'yahoo.at': true,
     'yahoo.be': true,


### PR DESCRIPTION
## Summary

Adds two newly identified alias domains so more equivalent addresses
normalize to the same value before hashing:

- `fastmail.ca` — Fastmail's own Canadian domain. Confirmed via MX
  records resolving to Fastmail's `messagingengine.com` infrastructure,
  and listed on Fastmail's official domain list.
- `myyahoo.com` — an alternate Yahoo-owned signup domain (WHOIS
  registrant: Yahoo Assets LLC), functionally identical to yahoo.com.

Both run on their provider's own native mail platform with no
third-party migration history, so the existing normalization logic
applies to them exactly as it does to their canonical counterparts.

This mirrors the same addition made to the minFraud web service's own
email normalization.

## Testing

49/49 tests pass (`npx vitest run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email normalization for Fastmail addresses using `fastmail.ca`.
  * Improved email normalization for Yahoo addresses using `myyahoo.com`.
  * Added coverage to verify correct domain handling and generated hashes for these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->